### PR TITLE
Fuzzy Search for Cardnames

### DIFF
--- a/src/CardService.js
+++ b/src/CardService.js
@@ -29,7 +29,7 @@ RiptideLab.CardService = (function(){
 
   // When a card is not found, Scryfall returns a json response and a 404 status
   async function getCardFromExternalService(cardName) {
-    const endpoint = 'cards/named?exact=' + encodeURIComponent(cardName);
+    const endpoint = 'cards/named?fuzzy=' + encodeURIComponent(cardName);
     let card;
 
     try {

--- a/src/CardService.js
+++ b/src/CardService.js
@@ -55,11 +55,13 @@ RiptideLab.CardService = (function(){
   }
 
   function isValid(card) {
-    return Boolean(card?.scryfall_uri && card.image_uris?.normal);
+    return Boolean(card?.name && card.scryfall_uri && card.image_uris?.normal);
   }
 
+  // A no-card must pass isValid()
   function getNoCard(cardName) {
     return {
+      name:cardName,
       isNoCard:true,
       scryfall_uri:'https://scryfall.com/search?q=' + encodeURIComponent(cardName),
       image_uris:{

--- a/src/CardService.js
+++ b/src/CardService.js
@@ -115,7 +115,7 @@ RiptideLab.CardService = (function(){
             localStorage.setItem(`RiptideLab--${exactName}`, JSON.stringify(card));
             localStorage.setItem(`RiptideLab--${exactName}-timestamp`, timeNow);
             // Fuzzy name can reference the exactName
-            localStorage.setItem(`RiptideLab--${cardName}`, `RiptideLab--${exactName}`);
+            localStorage.setItem(`RiptideLab--${cardName}`, `fuzzyReference--${exactName}`);
             localStorage.setItem(`RiptideLab--${cardName}-timestamp`, timeNow);
           }
         },
@@ -123,10 +123,11 @@ RiptideLab.CardService = (function(){
           if (memoryCache[cardName])
             return memoryCache[cardName];
           let cardJSON = localStorage.getItem(`RiptideLab--${cardName}`);
-          if (cardJSON?.startsWith('RiptideLab--')) // If this is a fuzzy reference, follow it
-            cardJSON = localStorage.getItem(cardJSON);
-          if (cardJSON)
+          if (cardJSON) {
+            if (cardJSON.startsWith('fuzzyReference--')) // If this is a fuzzy reference, follow it
+              return getFromFuzzyReference(cardJSON);
             return JSON.parse(cardJSON);
+          }
         }
       };
 
@@ -144,6 +145,13 @@ RiptideLab.CardService = (function(){
 
       function isCacheTimeStamp(string) {
         return string.substr(0,12) === 'RiptideLab--' && string.substr(-10) === '-timestamp';
+      }
+
+      function getFromFuzzyReference(fuzzyReference) {
+        const cardName = fuzzyReference.slice(16);
+        let cardJSON = localStorage.getItem(`RiptideLab--${cardName}`);
+        if (cardJSON)
+          return JSON.parse(cardJSON);
       }
     }
   }

--- a/src/CardService.js
+++ b/src/CardService.js
@@ -37,8 +37,14 @@ RiptideLab.CardService = (function(){
       card = await response.json(); // Had issues with blank responses on Edge
     } catch (error) {}
 
-    if (!isValid(card))
+    if (!isValid(card)){
       card = getNoCard(cardName);
+    }
+    if(card?.name?.toLowerCase() && cardName !== card?.name?.toLowerCase()){
+      //If it is fuzzy matched, then we want to cache the actual card
+      cardCache.addFuzzy(cardName, card.name.toLowerCase(), card)
+      return card;
+    }
     cardCache.add(cardName, card);
     return card;
   }
@@ -96,11 +102,29 @@ RiptideLab.CardService = (function(){
             localStorage.setItem(`RiptideLab--${cardName}-timestamp`, Date.now());
           }
         },
+        addFuzzy(cardName, exactName, card){
+          //Card should always be a valid card because of how this is called, but
+          //for safetly and extensibility...
+          if (card.isNoCard) {
+            memoryCache[cardName] = card;
+          } else {
+            const n = Date.now();
+            localStorage.setItem(`RiptideLab--${exactName}`, JSON.stringify(card));
+            localStorage.setItem(`RiptideLab--${exactName}-timestamp`, n);
+            //Fuzzy name can reference the exactName
+            localStorage.setItem(`RiptideLab--${cardName}`, `RiptideLab--${exactName}`);
+            localStorage.setItem(`RiptideLab--${cardName}-timestamp`, n);
+          }
+        },
         get(cardName) {
           if (memoryCache[cardName])
             return memoryCache[cardName];
 
-          const cardJSON = localStorage.getItem(`RiptideLab--${cardName}`);
+          var cardJSON = localStorage.getItem(`RiptideLab--${cardName}`);
+          if (cardJSON?.startsWith('RiptideLab--')){
+            //If this is a fuzzy reference, follow it
+            cardJSON = localStorage.getItem(cardJSON);
+          }
           if (cardJSON)
             return JSON.parse(cardJSON);
         }


### PR DESCRIPTION
Hi James,
Swapped from searching for an exact match to using the fuzzy search in Scryfall (see line 32). I don't know how the old deckbox search worked, so this might not be perfect for backwards compatibility, but should make 'Not the Boss' work in your test cases, and I can get as short as 'Brushwa'.
Tweaked the caching strategy for these inexact matches, so they just store a reference to the exact match. Kept the same timestamping key, so it should get cleaned up in the same cache cleanup step.