### PR TITLE
[Feature] Display Original Card Printings

### DIFF
--- a/src/CardService.js
+++ b/src/CardService.js
@@ -175,7 +175,7 @@ RiptideLab.CardService = (function(){
 
       // When a card is not found, Scryfall returns a json response and a 404 status
       try {
-        const response = await fetch('https://api.scryfall.com/cards/named?fuzzy=' + encodeURIComponent(cardName));
+        const response = await fetch('https://api.scryfall.com/cards/search?q=' + encodeURIComponent(cardName) + ' not:reprint');
         card = await response.json(); // Had issues with blank responses on Edge
       } catch (error) {} // If such a thing happens, we just move on
 

--- a/src/CardService.js
+++ b/src/CardService.js
@@ -173,9 +173,10 @@ RiptideLab.CardService = (function(){
     return {get};
 
     async function fetchScryfall(base, endpoint, cardName, useExact) {
-      if (useExact)
+      if (useExact) {
         // Wrap query in scryfall syntax for exact matching, eg. !"cardname". 
         cardName = '!"' + cardName + '"'
+      }        
 
       let basicLandQuery = 's:' + basicLandSet;
       let originalPrintingQuery = 'not:reprint';
@@ -186,7 +187,10 @@ RiptideLab.CardService = (function(){
       try {
           const response = await fetch(requestURL);
           card = await response.json(); // Had issues with blank responses on Edge
-        } catch (error) {} // If such a thing happens, we just move on
+      } 
+      catch (error) {
+        // If error happened, we just move on
+      } 
 
       return card
     }
@@ -202,19 +206,19 @@ RiptideLab.CardService = (function(){
 
       // When a card is not found, Scryfall returns a json response and a 404 status
       resp = await fetchScryfall(
-        base=scryfallAPIBase,
-        endpoint=scryfallQueryEndpoint,
-        cardName=cardName,
-        useExact=true
+        base = scryfallAPIBase,
+        endpoint = scryfallQueryEndpoint,
+        cardName = cardName,
+        useExact = true
       );
 
       // If exact match fails, retry with fuzzy match
       if (!didScryfallReturnResults(resp)) {
         resp = await fetchScryfall(
-          base=scryfallAPIBase,
-          endpoint=scryfallQueryEndpoint,
-          cardName=cardName,
-          useExact=false
+          base = scryfallAPIBase,
+          endpoint = scryfallQueryEndpoint,
+          cardName = cardName,
+          useExact = false
         );
       }
 

--- a/src/CardService.js
+++ b/src/CardService.js
@@ -175,12 +175,12 @@ RiptideLab.CardService = (function(){
     async function fetchScryfall(base, endpoint, cardName, useExact) {
       if (useExact)
         // Wrap query in scryfall syntax for exact matching, eg. !"cardname". 
-        cardName = '!"' + cardName + '"'
+        cardName = `!"${cardName}"`
 
-      let basicLandQuery = 's:' + basicLandSet;
+      let basicLandQuery = `s:${basicLandSet}`;
       let originalPrintingQuery = 'not:reprint';
 
-      let filters =  '(' + basicLandQuery + " or " + originalPrintingQuery + ')';
+      let filters =  `(${basicLandQuery} or ${originalPrintingQuery})`;
       let requestURL = base + endpoint + cardName + filters;
 
       try {

--- a/src/CardService.js
+++ b/src/CardService.js
@@ -200,11 +200,8 @@ RiptideLab.CardService = (function(){
     }
 
     async function get(cardName) {
-      let resp;
-      let card;
-
       // When a card is not found, Scryfall returns a json response and a 404 status
-      resp = await fetchScryfall(
+      let resp = await fetchScryfall(
         scryfallAPIBase,
         scryfallQueryEndpoint,
         cardName,
@@ -221,6 +218,7 @@ RiptideLab.CardService = (function(){
         );
       }
 
+      let card;
       // The /cards/search endpoint returns a list of cards. Grab the first result.
       if (didScryfallReturnResults(resp)) {
         card = resp.data[0];

--- a/src/CardService.js
+++ b/src/CardService.js
@@ -179,6 +179,12 @@ RiptideLab.CardService = (function(){
         card = await response.json(); // Had issues with blank responses on Edge
       } catch (error) {} // If such a thing happens, we just move on
 
+      // The /cards/search endpoint returns a list of cards. Grab the first result.
+      if (card) {
+        console.log(card);
+        card = card["data"][0];
+      }
+
       if (isValid(card))
         card = getLessDetailed(card); // Remove unused properties, since we're going to cache this
       else

--- a/src/CardService.js
+++ b/src/CardService.js
@@ -202,19 +202,19 @@ RiptideLab.CardService = (function(){
 
       // When a card is not found, Scryfall returns a json response and a 404 status
       resp = await fetchScryfall(
-        base=scryfallAPIBase,
-        endpoint=scryfallQueryEndpoint,
-        cardName=cardName,
-        useExact=true
+        scryfallAPIBase,
+        scryfallQueryEndpoint,
+        cardName,
+        true
       );
 
       // If exact match fails, retry with fuzzy match
       if (!didScryfallReturnResults(resp)) {
         resp = await fetchScryfall(
-          base=scryfallAPIBase,
-          endpoint=scryfallQueryEndpoint,
-          cardName=cardName,
-          useExact=false
+          scryfallAPIBase,
+          scryfallQueryEndpoint,
+          cardName,
+          false
         );
       }
 

--- a/test/index.html
+++ b/test/index.html
@@ -55,7 +55,11 @@
 <img src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs%3D" class="RiptideLab--unloaded-card-image small" data-card-name="gravecrawler">
 <img src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs%3D" class="RiptideLab--unloaded-card-image small" data-card-name="aurelia the warleader">
 <img src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs%3D" class="RiptideLab--unloaded-card-image small" data-card-name="doomsday">
+<img src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs%3D" class="RiptideLab--unloaded-card-image small" data-card-name="temple garden">
+
 <br>
+<br>
+<h3>Basic Lands</h3>
 <img src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs%3D" class="RiptideLab--unloaded-card-image small" data-card-name="plains">
 <img src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs%3D" class="RiptideLab--unloaded-card-image small" data-card-name="island">
 <img src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs%3D" class="RiptideLab--unloaded-card-image small" data-card-name="swamp">

--- a/test/index.html
+++ b/test/index.html
@@ -44,11 +44,23 @@
 <img src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs%3D" class="RiptideLab--unloaded-card-image small" data-card-name="Ice Cauldron">
 <img src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs%3D" class="RiptideLab--unloaded-card-image small" data-card-name="Gilder Bairn">
 <img src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs%3D" class="RiptideLab--unloaded-card-image small" data-card-name="Toshiro Umezawa">
-<img src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs%3D" class="RiptideLab--unloaded-card-image small" data-card-name="iahfgkdsjg">
+<!-- <img src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs%3D" class="RiptideLab--unloaded-card-image small" data-card-name="iahfgkdsjg"> -->
 
 <h3>Split Cards</h3>
 <img src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs%3D" class="RiptideLab--unloaded-card-image small" data-card-name="embereth shieldbreaker">
 <img src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs%3D" class="RiptideLab--unloaded-card-image small" data-card-name="never return">
+
+
+<h3> Original Printings</h3>
+<img src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs%3D" class="RiptideLab--unloaded-card-image small" data-card-name="gravecrawler">
+<img src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs%3D" class="RiptideLab--unloaded-card-image small" data-card-name="aurelia the warleader">
+<img src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs%3D" class="RiptideLab--unloaded-card-image small" data-card-name="doomsday">
+<br>
+<img src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs%3D" class="RiptideLab--unloaded-card-image small" data-card-name="plains">
+<img src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs%3D" class="RiptideLab--unloaded-card-image small" data-card-name="island">
+<img src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs%3D" class="RiptideLab--unloaded-card-image small" data-card-name="swamp">
+<img src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs%3D" class="RiptideLab--unloaded-card-image small" data-card-name="mountain">
+<img src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs%3D" class="RiptideLab--unloaded-card-image small" data-card-name="forest">
 
 <!-- Testing card names -->
 <h3>Known cards</h3>
@@ -109,7 +121,7 @@
 <a class=RiptideLab--card-hover href="https://scryfall.com/search?q=Zur the enchanter" target=_blank data-card-name="Zur the enchanter">Zur the enchanter</a>
 
 <h3>Spelled too wrong</h3>
-<a class=RiptideLab--card-hover href="https://scryfall.com/search?q=steamfluglehaben boss" target=_blank data-card-name="steamfluglehaben boss">steamfluglehaben boss</a>
+<a class=RiptideLab--card-hover href="https://scryfall.com/search?q=steamflogger boss" target=_blank data-card-name="steamflogger boss">steamfluglehaben boss</a>
 
 <!-- We want to be able to scroll far enough that the scroll test cases are not by the bottom of the viewport -->
 <br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br>

--- a/test/index.html
+++ b/test/index.html
@@ -125,7 +125,7 @@
 <a class=RiptideLab--card-hover href="https://scryfall.com/search?q=Zur the enchanter" target=_blank data-card-name="Zur the enchanter">Zur the enchanter</a>
 
 <h3>Spelled too wrong</h3>
-<a class=RiptideLab--card-hover href="https://scryfall.com/search?q=steamfluglehaben" target=_blank data-card-name="steamfluglehaben">steamfluglehaben boss</a>
+<a class=RiptideLab--card-hover href="https://scryfall.com/search?q=steamfluglehaben boss" target=_blank data-card-name="steamfluglehaben boss">steamfluglehaben boss</a>
 
 <!-- We want to be able to scroll far enough that the scroll test cases are not by the bottom of the viewport -->
 <br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br>

--- a/test/index.html
+++ b/test/index.html
@@ -125,7 +125,7 @@
 <a class=RiptideLab--card-hover href="https://scryfall.com/search?q=Zur the enchanter" target=_blank data-card-name="Zur the enchanter">Zur the enchanter</a>
 
 <h3>Spelled too wrong</h3>
-<a class=RiptideLab--card-hover href="https://scryfall.com/search?q=steamflogger boss" target=_blank data-card-name="steamflogger boss">steamfluglehaben boss</a>
+<a class=RiptideLab--card-hover href="https://scryfall.com/search?q=steamfluglehaben" target=_blank data-card-name="steamfluglehaben">steamfluglehaben boss</a>
 
 <!-- We want to be able to scroll far enough that the scroll test cases are not by the bottom of the viewport -->
 <br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br>

--- a/test/index.html
+++ b/test/index.html
@@ -44,7 +44,7 @@
 <img src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs%3D" class="RiptideLab--unloaded-card-image small" data-card-name="Ice Cauldron">
 <img src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs%3D" class="RiptideLab--unloaded-card-image small" data-card-name="Gilder Bairn">
 <img src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs%3D" class="RiptideLab--unloaded-card-image small" data-card-name="Toshiro Umezawa">
-<!-- <img src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs%3D" class="RiptideLab--unloaded-card-image small" data-card-name="iahfgkdsjg"> -->
+<img src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs%3D" class="RiptideLab--unloaded-card-image small" data-card-name="iahfgkdsjg">
 
 <h3>Split Cards</h3>
 <img src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs%3D" class="RiptideLab--unloaded-card-image small" data-card-name="embereth shieldbreaker">


### PR DESCRIPTION
Hello!
My name is Vanessa (AKA [vennythekid](https://riptidelab.com/forum/members/vennythekid.213/)), a long-time Riptider and cube sicko.

This is a feature to update the `CardService` to only fetch the original printing of a card. I've done the following:
- Changed the Scryfall endpoint from `/cards/named` to `cards/search` to support filtering on card versions.
- Added an additional `not:reprint` filter to the query for the card. This will always return the first printing of a card.
- Because `/cards/search` returns an array of cards, return the first result from the response.

To support fuzzy searching, the `/cards/search` request must be made twice: First, with an exact match query and second without. This is because there are edge cases such as "Island", [which matches [[Dirgur Island Dragon]] as well as [[Tropical Island]] and [[Volcanic Island]]](https://scryfall.com/search?q=island+not%3Areprint). In these cases, the service must first attempt an exact match to return [[Island]]. Then, if no exact match is found, fall back to the fuzzy search as before.

To test this feature, I added additional test cases to the `tests/index.html` and verified them locally. 

Please let me know what the next steps for merging this feature. This is my first one so anything you need me to do process-wise, I'm more than happy to support!