### PR TITLE
[Feature] Request card version

### DIFF
--- a/src/CardService.js
+++ b/src/CardService.js
@@ -175,7 +175,7 @@ RiptideLab.CardService = (function(){
 
       // When a card is not found, Scryfall returns a json response and a 404 status
       try {
-        const response = await fetch('https://api.scryfall.com/cards/named?fuzzy=' + encodeURIComponent(cardName));
+        const response = await fetch('https://api.scryfall.com/cards/search?q=' + encodeURIComponent(cardName) + ' not:reprint');
         card = await response.json(); // Had issues with blank responses on Edge
       } catch (error) {} // If such a thing happens, we just move on
 

--- a/src/CardService.js
+++ b/src/CardService.js
@@ -224,20 +224,20 @@ RiptideLab.CardService = (function(){
 
       // When a card is not found, Scryfall returns a json response and a 404 status
       resp = await fetchScryfall(
-        base=scryfallAPIBase,
-        endpoint=scryfallQueryEndpoint,
-        cardName=cardBaseName,
-        useExact=true,
-        cardSet=cardSet
+        scryfallAPIBase,
+        scryfallQueryEndpoint,
+        cardBaseName,
+        true,
+        cardSet
       );
 
       // If exact match fails, retry with fuzzy match
       if (!didScryfallReturnResults(resp)) {
         resp = await fetchScryfall(
-          base=scryfallAPIBase,
-          endpoint=scryfallQueryEndpoint,
-          cardName=cardBaseName,
-          useExact=false
+          scryfallAPIBase,
+          scryfallQueryEndpoint,
+          cardBaseName,
+          false
         );
       }
 

--- a/src/CardService.js
+++ b/src/CardService.js
@@ -178,7 +178,7 @@ RiptideLab.CardService = (function(){
     async function fetchScryfall(base, endpoint, cardName, useExact, cardSet=null) {
       if (useExact) {
         // Wrap query in scryfall syntax for exact matching, eg. !"cardname". 
-        cardName = '!"' + cardName + '"'
+        cardName = `!"${cardName}"`;
       }
 
       let basicLandQuery = 's:' + basicLandSet;
@@ -186,12 +186,12 @@ RiptideLab.CardService = (function(){
       let filters;
 
       if (cardSet) {
-        filters = "s:" + cardSet + " order:set";
+        filters = `s:${cardSet} order:set`;
       } else {
-        filters =  '(' + basicLandQuery + " or " + originalPrintingQuery + ')';
+        filters =  `(${basicLandQuery} or ${originalPrintingQuery})`;
       }
 
-      let requestURL = base + endpoint + cardName + filters;
+      const requestURL = base + endpoint + cardName + filters;
 
       try {
           const response = await fetch(requestURL);
@@ -207,7 +207,6 @@ RiptideLab.CardService = (function(){
     }
 
     async function get(cardName) {
-      let resp;
       let card;
       let cardBaseName;
       let cardSet;
@@ -223,7 +222,7 @@ RiptideLab.CardService = (function(){
       }
 
       // When a card is not found, Scryfall returns a json response and a 404 status
-      resp = await fetchScryfall(
+      let resp = await fetchScryfall(
         scryfallAPIBase,
         scryfallQueryEndpoint,
         cardBaseName,

--- a/src/CardService.js
+++ b/src/CardService.js
@@ -98,14 +98,17 @@ RiptideLab.CardService = (function(){
       return {
         add(cardName, card) {
           const exactName = card.name.toLowerCase();
-          if (cardName !== exactName) // Fuzzy matched or double faced
+          if (cardName !== exactName & !cardName.includes("|")) { // Fuzzy matched or double faced, but not exact set matches
             addFuzzy(cardName, exactName, card);
-          else
+          }
+          else {
             addExact(cardName, card);
+          }
         },
         get(cardName) {
-          if (memoryCache[cardName])
+          if (memoryCache[cardName]) {
             return memoryCache[cardName];
+          }
           let cardJSON = localStorage.getItem(`RiptideLab--${cardName}`);
           if (cardJSON) {
             if (cardJSON.startsWith('fuzzyReference--')) // If this is a fuzzy reference, follow it
@@ -206,13 +209,16 @@ RiptideLab.CardService = (function(){
     async function get(cardName) {
       let resp;
       let card;
+      let cardBaseName;
+      let cardSet;
 
       // If a specific set is requested, it is of the form "cardName|set", eg. "temple garden|rtr"
       if (cardName.includes("|")) {
         let textData = cardName.split("|");
-        cardName = textData[0];
+        cardBaseName = textData[0];
         cardSet = textData[1];
       } else {
+        cardBaseName = cardName;
         cardSet = null;
       }
 
@@ -220,7 +226,7 @@ RiptideLab.CardService = (function(){
       resp = await fetchScryfall(
         base=scryfallAPIBase,
         endpoint=scryfallQueryEndpoint,
-        cardName=cardName,
+        cardName=cardBaseName,
         useExact=true,
         cardSet=cardSet
       );
@@ -230,7 +236,7 @@ RiptideLab.CardService = (function(){
         resp = await fetchScryfall(
           base=scryfallAPIBase,
           endpoint=scryfallQueryEndpoint,
-          cardName=cardName,
+          cardName=cardBaseName,
           useExact=false
         );
       }

--- a/src/CardService.js
+++ b/src/CardService.js
@@ -179,6 +179,12 @@ RiptideLab.CardService = (function(){
         card = await response.json(); // Had issues with blank responses on Edge
       } catch (error) {} // If such a thing happens, we just move on
 
+      // The /cards/search endpoint returns a list of cards. Grab the first result.
+      if (card) {
+        console.log(card);
+        card = card["data"][0];
+      }
+
       if (isValid(card))
         card = getLessDetailed(card); // Remove unused properties, since we're going to cache this
       else

--- a/src/CardService.js
+++ b/src/CardService.js
@@ -98,7 +98,7 @@ RiptideLab.CardService = (function(){
       return {
         add(cardName, card) {
           const exactName = card.name.toLowerCase();
-          if (cardName !== exactName & !cardName.includes("|")) { // Fuzzy matched or double faced, but not exact set matches
+          if (cardName !== exactName && !cardName.includes("|")) { // Fuzzy matched or double faced, but not exact set matches
             addFuzzy(cardName, exactName, card);
           }
           else {

--- a/test/index.html
+++ b/test/index.html
@@ -55,7 +55,11 @@
 <img src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs%3D" class="RiptideLab--unloaded-card-image small" data-card-name="gravecrawler">
 <img src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs%3D" class="RiptideLab--unloaded-card-image small" data-card-name="aurelia the warleader">
 <img src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs%3D" class="RiptideLab--unloaded-card-image small" data-card-name="doomsday">
+<img src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs%3D" class="RiptideLab--unloaded-card-image small" data-card-name="temple garden">
+
 <br>
+<br>
+<h3>Basic Lands</h3>
 <img src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs%3D" class="RiptideLab--unloaded-card-image small" data-card-name="plains">
 <img src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs%3D" class="RiptideLab--unloaded-card-image small" data-card-name="island">
 <img src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs%3D" class="RiptideLab--unloaded-card-image small" data-card-name="swamp">

--- a/test/index.html
+++ b/test/index.html
@@ -61,16 +61,31 @@
 <br>
 
 <h3> Specific Printings</h3>
-<h4>M21 Cancel</h4>
+<h4>Cancel: M21, RTR, M10, ZEN</h4>
 <img src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs%3D" class="RiptideLab--unloaded-card-image small" data-card-name="cancel|m21">
-<h4>RTR Cancel</h4>
 <img src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs%3D" class="RiptideLab--unloaded-card-image small" data-card-name="cancel|rtr">
-<h4>M10 Cancel</h4>
 <img src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs%3D" class="RiptideLab--unloaded-card-image small" data-card-name="cancel|m10">
-<h4>ZEN Cancel</h4>
 <img src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs%3D" class="RiptideLab--unloaded-card-image small" data-card-name="cancel|zen">
+<h4>Temple Garden: RAV, RTR, GRN</h4>
+<img src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs%3D" class="RiptideLab--unloaded-card-image small" data-card-name="temple garden|rav">
+<img src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs%3D" class="RiptideLab--unloaded-card-image small" data-card-name="temple garden|rtr">
+<img src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs%3D" class="RiptideLab--unloaded-card-image small" data-card-name="temple garden|grn">
+
+
 
 <br>
+<h4>Test that set specific requests return the lowest collector number ("traditional" treatment)</h4>
+<img src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs%3D" class="RiptideLab--unloaded-card-image small" data-card-name="starfield vocalist|eoe">
+<img src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs%3D" class="RiptideLab--unloaded-card-image small" data-card-name="spectacular pileup|dft">
+<img src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs%3D" class="RiptideLab--unloaded-card-image small" data-card-name="narset jeskai waymaster|tdm">
+<img src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs%3D" class="RiptideLab--unloaded-card-image small" data-card-name="sothera the supervoid|eoe">
+<br>
+
+<h4>Test that invalid card/set combinations return null</h4>
+<img src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs%3D" class="RiptideLab--unloaded-card-image small" data-card-name="temple garden|m21">
+<img src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs%3D" class="RiptideLab--unloaded-card-image small" data-card-name="temple garden|ravv">
+<img src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs%3D" class="RiptideLab--unloaded-card-image small" data-card-name="temple garden|">
+
 <br>
 
 

--- a/test/index.html
+++ b/test/index.html
@@ -59,6 +59,21 @@
 
 <br>
 <br>
+
+<h3> Specific Printings</h3>
+<h4>M21 Cancel</h4>
+<img src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs%3D" class="RiptideLab--unloaded-card-image small" data-card-name="cancel|m21">
+<h4>RTR Cancel</h4>
+<img src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs%3D" class="RiptideLab--unloaded-card-image small" data-card-name="cancel|rtr">
+<h4>M10 Cancel</h4>
+<img src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs%3D" class="RiptideLab--unloaded-card-image small" data-card-name="cancel|m10">
+<h4>ZEN Cancel</h4>
+<img src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs%3D" class="RiptideLab--unloaded-card-image small" data-card-name="cancel|zen">
+
+<br>
+<br>
+
+
 <h3>Basic Lands</h3>
 <img src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs%3D" class="RiptideLab--unloaded-card-image small" data-card-name="plains">
 <img src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs%3D" class="RiptideLab--unloaded-card-image small" data-card-name="island">

--- a/test/index.html
+++ b/test/index.html
@@ -44,11 +44,23 @@
 <img src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs%3D" class="RiptideLab--unloaded-card-image small" data-card-name="Ice Cauldron">
 <img src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs%3D" class="RiptideLab--unloaded-card-image small" data-card-name="Gilder Bairn">
 <img src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs%3D" class="RiptideLab--unloaded-card-image small" data-card-name="Toshiro Umezawa">
-<img src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs%3D" class="RiptideLab--unloaded-card-image small" data-card-name="iahfgkdsjg">
+<!-- <img src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs%3D" class="RiptideLab--unloaded-card-image small" data-card-name="iahfgkdsjg"> -->
 
 <h3>Split Cards</h3>
 <img src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs%3D" class="RiptideLab--unloaded-card-image small" data-card-name="embereth shieldbreaker">
 <img src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs%3D" class="RiptideLab--unloaded-card-image small" data-card-name="never return">
+
+
+<h3> Original Printings</h3>
+<img src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs%3D" class="RiptideLab--unloaded-card-image small" data-card-name="gravecrawler">
+<img src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs%3D" class="RiptideLab--unloaded-card-image small" data-card-name="aurelia the warleader">
+<img src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs%3D" class="RiptideLab--unloaded-card-image small" data-card-name="doomsday">
+<br>
+<img src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs%3D" class="RiptideLab--unloaded-card-image small" data-card-name="plains">
+<img src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs%3D" class="RiptideLab--unloaded-card-image small" data-card-name="island">
+<img src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs%3D" class="RiptideLab--unloaded-card-image small" data-card-name="swamp">
+<img src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs%3D" class="RiptideLab--unloaded-card-image small" data-card-name="mountain">
+<img src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs%3D" class="RiptideLab--unloaded-card-image small" data-card-name="forest">
 
 <!-- Testing card names -->
 <h3>Known cards</h3>
@@ -109,7 +121,7 @@
 <a class=RiptideLab--card-hover href="https://scryfall.com/search?q=Zur the enchanter" target=_blank data-card-name="Zur the enchanter">Zur the enchanter</a>
 
 <h3>Spelled too wrong</h3>
-<a class=RiptideLab--card-hover href="https://scryfall.com/search?q=steamfluglehaben boss" target=_blank data-card-name="steamfluglehaben boss">steamfluglehaben boss</a>
+<a class=RiptideLab--card-hover href="https://scryfall.com/search?q=steamflogger boss" target=_blank data-card-name="steamflogger boss">steamfluglehaben boss</a>
 
 <!-- We want to be able to scroll far enough that the scroll test cases are not by the bottom of the viewport -->
 <br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br>

--- a/test/index.html
+++ b/test/index.html
@@ -125,7 +125,7 @@
 <a class=RiptideLab--card-hover href="https://scryfall.com/search?q=Zur the enchanter" target=_blank data-card-name="Zur the enchanter">Zur the enchanter</a>
 
 <h3>Spelled too wrong</h3>
-<a class=RiptideLab--card-hover href="https://scryfall.com/search?q=steamfluglehaben" target=_blank data-card-name="steamfluglehaben">steamfluglehaben boss</a>
+<a class=RiptideLab--card-hover href="https://scryfall.com/search?q=steamfluglehaben boss" target=_blank data-card-name="steamfluglehaben boss">steamfluglehaben boss</a>
 
 <!-- We want to be able to scroll far enough that the scroll test cases are not by the bottom of the viewport -->
 <br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br>

--- a/test/index.html
+++ b/test/index.html
@@ -125,7 +125,7 @@
 <a class=RiptideLab--card-hover href="https://scryfall.com/search?q=Zur the enchanter" target=_blank data-card-name="Zur the enchanter">Zur the enchanter</a>
 
 <h3>Spelled too wrong</h3>
-<a class=RiptideLab--card-hover href="https://scryfall.com/search?q=steamflogger boss" target=_blank data-card-name="steamflogger boss">steamfluglehaben boss</a>
+<a class=RiptideLab--card-hover href="https://scryfall.com/search?q=steamfluglehaben" target=_blank data-card-name="steamfluglehaben">steamfluglehaben boss</a>
 
 <!-- We want to be able to scroll far enough that the scroll test cases are not by the bottom of the viewport -->
 <br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br>

--- a/test/index.html
+++ b/test/index.html
@@ -44,7 +44,7 @@
 <img src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs%3D" class="RiptideLab--unloaded-card-image small" data-card-name="Ice Cauldron">
 <img src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs%3D" class="RiptideLab--unloaded-card-image small" data-card-name="Gilder Bairn">
 <img src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs%3D" class="RiptideLab--unloaded-card-image small" data-card-name="Toshiro Umezawa">
-<!-- <img src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs%3D" class="RiptideLab--unloaded-card-image small" data-card-name="iahfgkdsjg"> -->
+<img src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs%3D" class="RiptideLab--unloaded-card-image small" data-card-name="iahfgkdsjg">
 
 <h3>Split Cards</h3>
 <img src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs%3D" class="RiptideLab--unloaded-card-image small" data-card-name="embereth shieldbreaker">


### PR DESCRIPTION
Hello again! 
While I has this fresh in my head, I decided to take a crack at card version specification as well. The BBCode syntax for this is `[c=cardName|set]` where `cardName` is the name of the card and `set` is the 3-letter set code.

This method checks to see if the `cardName` is formatted as `"cardName|set"`, and if is, parse the set code and add that filter to the scryfall query. A few other things to note:
- Include `order:set` in the scryfall query to order the results by set number, which is the most reliable way to get the "traditional" treatment of a card (excluding extras, full arts, etc).
- Force the cache to store this as an exact name (rather than fuzzy) because the set codes must match.

I built this PR atop #8 so this should be merged after that one is deployed and verified. Appologies for the sloppy versioning; I may need to rebase this. New feature code for this PR starting from [this commit](https://github.com/mooseling/RiptideLab/tree/1aa07c51ccc8ab422da2af419543b11704043acc).